### PR TITLE
add broken part check(404) to cloud table checksums for part load

### DIFF
--- a/src/Storages/MergeTree/MergeTreeCloudData.h
+++ b/src/Storages/MergeTree/MergeTreeCloudData.h
@@ -42,6 +42,7 @@ public:
     /// Load prepared parts, deactivate outdated parts and construct coverage link
     /// [Preallocate Mode] if worker_topology_hash is not empty, need to check whether the given topology is matched with worker's topology
     void loadDataParts(MutableDataPartsVector & parts, UInt64 worker_topology_hash = 0);
+    bool loadDataPart(MutableDataPartPtr part);
 
     /// Remove Outdated parts of which timestamp is less than expired ts from container.
     /// DO NOT check reference count of parts.

--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
@@ -773,7 +773,13 @@ IMergeTreeDataPart::ChecksumsPtr MergeTreeDataPartCNCH::loadChecksumsFromRemote(
         return checksums;
 
     String data_rel_path = fs::path(getFullRelativePath()) / DATA_FILE;
-    auto data_footer = loadPartDataFooter();
+    MergeTreeDataPartChecksums::FileChecksums data_footer;
+    try {
+        data_footer = loadPartDataFooter();
+    }
+    catch (...) {
+        throw Exception(ErrorCodes::NO_FILE_IN_DATA_PART, "The checksums file in part {} under path {} does not exist", name, data_rel_path);
+    }
     const auto & checksum_file = data_footer["checksums.txt"];
 
     if (checksum_file.file_size == 0 /* && isDeleted() */)


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MergeTreeCloud reads were failing if a part was not found on S3 after a crash on the server side. Added broken check like the actual MergeTree. 

### Error Logs

Could not load checksums from remote: Code: 499, e.displayText() = DB::S3::S3Exception: Encounter exception when request s3, HTTP Code: 404, RemoteHost: , RequestID: , ExceptionName: , ErrorMessage: No response body., Extra:  SQLSTATE: HY000, Stack trace (when copying this message, always include the lines below)

Broken parts count on start is bigger than 0, count: 3
