### PR TITLE
add per table sample size and ndv settings for auto sample

### DIFF
--- a/src/CloudServices/CnchServerServiceImpl.cpp
+++ b/src/CloudServices/CnchServerServiceImpl.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <CloudServices/CnchServerServiceImpl.h>
+#include <CloudServices/HotCachePreloadHelper.h>
 
 #include <Catalog/Catalog.h>
 #include <Catalog/CatalogUtils.h>
@@ -1635,6 +1636,11 @@ void CnchServerServiceImpl::submitPreloadTask(
     });
 }
 
+bool isPreloadTopologyReady(const std::list<CnchServerTopology> & topology)
+{
+    return !topology.empty() && !topology.back().getServerList().empty();
+}
+
 void CnchServerServiceImpl::preloadHotCacheTables(
     google::protobuf::RpcController * cntl,
     const Protos::PreloadHotCacheTablesReq * request,
@@ -1668,6 +1674,13 @@ void CnchServerServiceImpl::preloadHotCacheTables(
             UInt32 preloaded = 0;
             auto catalog = rpc_context->getCnchCatalog();
             auto topology = rpc_context->getCnchTopologyMaster();
+
+            /// If our topology view has not settled yet, we cannot resolve table ownership and would silently warm
+            /// nothing. Report not-ready so the daemon defers and retries on a later tick instead of consuming the worker-restart event.
+            if (!isPreloadTopologyReady(topology->getCurrentTopology()))
+                throw Exception(
+                    "preloadHotCacheTables: server topology not settled yet, deferring preload",
+                    ErrorCodes::CNCH_TOPOLOGY_NOT_MATCH_ERROR);
 
             /// Scan tables; act only on the TTL-cached ones this server hosts.
             for (const auto & model : catalog->getAllTables(request->database()))

--- a/src/CloudServices/HotCachePreloadHelper.h
+++ b/src/CloudServices/HotCachePreloadHelper.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2022) Bytedance Ltd. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <list>
+#include <MergeTreeCommon/CnchServerTopology.h>
+
+namespace DB
+{
+
+/// A server can only resolve which TTL-cached tables it owns once its topology view has
+/// settled. Immediately after a (re)start getCurrentTopology() is empty until the topology
+/// is fetched, so a hot-cache preload sweep in that window would silently own nothing.
+/// Returns false while the (latest) topology has no servers, so the server reports
+/// not-ready and the cache-preload daemon retries the broadcast instead of consuming the
+/// worker-restart event and leaving caches cold.
+bool isPreloadTopologyReady(const std::list<CnchServerTopology> & topology);
+
+}

--- a/src/CloudServices/tests/gtest_hot_cache_preload.cpp
+++ b/src/CloudServices/tests/gtest_hot_cache_preload.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2022) Bytedance Ltd. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <CloudServices/HotCachePreloadHelper.h>
+#include <MergeTreeCommon/CnchServerTopology.h>
+#include <Common/HostWithPorts.h>
+#include <gtest/gtest.h>
+
+#include <list>
+
+namespace GtestHotCachePreload
+{
+
+using namespace DB;
+
+namespace
+{
+CnchServerTopology topologyWith(const std::vector<String> & server_hosts)
+{
+    CnchServerTopology topo;
+    for (const auto & h : server_hosts)
+        topo.addServer(HostWithPorts(h, /*rpc_port=*/1234));
+    return topo;
+}
+}
+
+/// Right after a server (re)start getCurrentTopology() is empty until the topology is
+/// fetched. The server must report not-ready so the cache-preload daemon retries instead
+/// of consuming the worker-restart event -- the simultaneous server+worker restart gap.
+TEST(HotCachePreload, empty_topology_not_ready)
+{
+    EXPECT_FALSE(isPreloadTopologyReady(std::list<CnchServerTopology>{}));
+}
+
+/// A topology entry whose server list is empty is likewise not settled.
+TEST(HotCachePreload, topology_with_no_servers_not_ready)
+{
+    std::list<CnchServerTopology> topology{topologyWith({})};
+    EXPECT_FALSE(isPreloadTopologyReady(topology));
+}
+
+/// A settled topology (has servers) lets the server resolve ownership and warm -- ready.
+TEST(HotCachePreload, settled_topology_ready)
+{
+    std::list<CnchServerTopology> topology{topologyWith({"10.0.0.1", "10.0.0.2"})};
+    EXPECT_TRUE(isPreloadTopologyReady(topology));
+}
+
+/// Readiness keys off the most-recent topology (back()): an empty latest entry means a
+/// fresh cluster event has not settled yet, even if an older entry still had servers.
+TEST(HotCachePreload, latest_topology_empty_not_ready)
+{
+    std::list<CnchServerTopology> topology{topologyWith({"10.0.0.1"}), topologyWith({})};
+    EXPECT_FALSE(isPreloadTopologyReady(topology));
+}
+
+/// A single-server settled topology is ready.
+TEST(HotCachePreload, single_server_ready)
+{
+    std::list<CnchServerTopology> topology{topologyWith({"10.0.0.1"})};
+    EXPECT_TRUE(isPreloadTopologyReady(topology));
+}
+
+} // namespace GtestHotCachePreload

--- a/src/Statistics/AutoStatisticsManager.cpp
+++ b/src/Statistics/AutoStatisticsManager.cpp
@@ -345,6 +345,22 @@ bool AutoStatisticsManager::executeOneTask(const std::shared_ptr<TaskInfo> & cho
             settings.fromJsonStr(chosen_task->getSettingsJson());
         }
 
+        // Overlay per-table auto-stats overrides (0 / empty = inherit server defaults).
+        if (auto storage = catalog->tryGetStorageByUUID(uuid))
+        {
+            if (auto * mt = dynamic_cast<MergeTreeMetaBase *>(storage.get()))
+            {
+                const auto & table_settings = mt->getSettings();
+                if (table_settings->statistics_auto_sample_ratio > 0)
+                    settings.sample_ratio = table_settings->statistics_auto_sample_ratio;
+                if (table_settings->statistics_auto_sample_row_count > 0)
+                    settings.sample_row_count = table_settings->statistics_auto_sample_row_count;
+                const auto & ndv_mode = table_settings->statistics_auto_accurate_sample_ndv.value;
+                if (!ndv_mode.empty())
+                    settings.accurate_sample_ndv = SettingFieldStatisticsAccurateSampleNdvModeTraits::fromString(ndv_mode);
+            }
+        }
+
         auto task_context = Context::createCopy(context);
         task_context->makeQueryContext();
         auto [interserver_user, interserver_password] = const_cast<const Context &>(*task_context).getCnchInterserverCredentials();

--- a/src/Statistics/AutoStatisticsManager.cpp
+++ b/src/Statistics/AutoStatisticsManager.cpp
@@ -345,20 +345,17 @@ bool AutoStatisticsManager::executeOneTask(const std::shared_ptr<TaskInfo> & cho
             settings.fromJsonStr(chosen_task->getSettingsJson());
         }
 
-        // Overlay per-table auto-stats overrides (0 / empty = inherit server defaults).
-        if (auto storage = catalog->tryGetStorageByUUID(uuid))
+        // Overlay per-table auto-stats overrides
+        auto storage = catalog->tryGetStorageByUUID(uuid);
+        if (auto * mt = storage ? dynamic_cast<MergeTreeMetaBase *>(storage.get()) : nullptr)
         {
-            if (auto * mt = dynamic_cast<MergeTreeMetaBase *>(storage.get()))
-            {
-                const auto & table_settings = mt->getSettings();
-                if (table_settings->statistics_auto_sample_ratio > 0)
-                    settings.sample_ratio = table_settings->statistics_auto_sample_ratio;
-                if (table_settings->statistics_auto_sample_row_count > 0)
-                    settings.sample_row_count = table_settings->statistics_auto_sample_row_count;
-                const auto & ndv_mode = table_settings->statistics_auto_accurate_sample_ndv.value;
-                if (!ndv_mode.empty())
-                    settings.accurate_sample_ndv = SettingFieldStatisticsAccurateSampleNdvModeTraits::fromString(ndv_mode);
-            }
+            const auto & table_settings = mt->getSettings();
+            if (table_settings->statistics_auto_sample_ratio > 0)
+                settings.sample_ratio = table_settings->statistics_auto_sample_ratio;
+            if (table_settings->statistics_auto_sample_row_count > 0)
+                settings.sample_row_count = table_settings->statistics_auto_sample_row_count;
+            if (table_settings->statistics_auto_accurate_sample_ndv.changed)
+                settings.accurate_sample_ndv = table_settings->statistics_auto_accurate_sample_ndv;
         }
 
         auto task_context = Context::createCopy(context);

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -508,6 +508,9 @@ enum StealingCacheMode : UInt64
     M(UInt64, disk_cache_ttl_hours, 0, "Per-table TTL cache: cache parts with max_timestamp within this age. 0 = disabled (use global LRU). >0 = enable per-table TTL cache.", 0) \
     M(UInt64, disk_cache_max_size_bytes, 0, "Per-table cache size limit in bytes. 0 = unlimited (constrained by global limit). Only applies when disk_cache_ttl_hours > 0.", 0) \
     M(Bool, enable_auto_statistics, false, "Enable automatic statistics collection for this table. When enabled, stats are collected after sufficient data changes (controlled by server-level update_ratio_threshold).", 0) \
+    M(Float, statistics_auto_sample_ratio, 0, "Per-table override for auto statistics sample ratio. 0 = inherit server default (statistics_sample_ratio).", 0) \
+    M(UInt64, statistics_auto_sample_row_count, 0, "Per-table override for auto statistics minimal sample row count. 0 = inherit server default (statistics_sample_row_count).", 0) \
+    M(String, statistics_auto_accurate_sample_ndv, "", "Per-table override for auto statistics accurate-NDV mode (NEVER/AUTO/ALWAYS). Empty = inherit server default. Set NEVER on huge high-cardinality tables to skip the accurate-NDV GROUP BY pass that can OOM workers.", 0) \
     \
     /* Renamed settings - cannot be ignored */\
     M(Bool, enable_nullable_sorting_key, false, "Alias of `allow_nullable_key`", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -510,7 +510,7 @@ enum StealingCacheMode : UInt64
     M(Bool, enable_auto_statistics, false, "Enable automatic statistics collection for this table. When enabled, stats are collected after sufficient data changes (controlled by server-level update_ratio_threshold).", 0) \
     M(Float, statistics_auto_sample_ratio, 0, "Per-table override for auto statistics sample ratio. 0 = inherit server default (statistics_sample_ratio).", 0) \
     M(UInt64, statistics_auto_sample_row_count, 0, "Per-table override for auto statistics minimal sample row count. 0 = inherit server default (statistics_sample_row_count).", 0) \
-    M(String, statistics_auto_accurate_sample_ndv, "", "Per-table override for auto statistics accurate-NDV mode (NEVER/AUTO/ALWAYS). Empty = inherit server default. Set NEVER on huge high-cardinality tables to skip the accurate-NDV GROUP BY pass that can OOM workers.", 0) \
+    M(StatisticsAccurateSampleNdvMode, statistics_auto_accurate_sample_ndv, StatisticsAccurateSampleNdvMode::AUTO, "Per-table override for auto statistics accurate-NDV mode (NEVER/AUTO/ALWAYS). Defaults to AUTO; applied only when explicitly set. Set NEVER on huge high-cardinality tables to skip the accurate-NDV GROUP BY pass that can OOM workers.", 0) \
     \
     /* Renamed settings - cannot be ignored */\
     M(Bool, enable_nullable_sorting_key, false, "Alias of `allow_nullable_key`", 0) \


### PR DESCRIPTION
Very large tables oom or timeout with global sample \ ndv settings. This PR aims to give capability to calibrate per table.